### PR TITLE
Added path option for `config.yml`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,7 @@ pub struct Remote {
     pub host: String,
     pub user: Option<String>,
     pub port: Option<String>,
+    pub path: Option<String>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn main() {
     let mut remote_command_readers = remote_command::execute_remote_command(
         args.command(),
         config.clone(),
-        sync::project_dir_on_remote_machine(&local_dir_absolute_path),
+        sync::project_dir_on_remote_machine(&config, &local_dir_absolute_path),
         2,
     );
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -99,13 +99,15 @@ pub fn push(
         command.arg(format!(
             "{user}@{remote_machine_name}:{project_dir_on_remote_machine}",
             remote_machine_name = config.remote.host,
-            project_dir_on_remote_machine = project_dir_on_remote_machine(config, local_dir_absolute_path)
+            project_dir_on_remote_machine =
+                project_dir_on_remote_machine(config, local_dir_absolute_path)
         ));
     } else {
         command.arg(format!(
             "{remote_machine_name}:{project_dir_on_remote_machine}",
             remote_machine_name = config.remote.host,
-            project_dir_on_remote_machine = project_dir_on_remote_machine(config, local_dir_absolute_path)
+            project_dir_on_remote_machine =
+                project_dir_on_remote_machine(config, local_dir_absolute_path)
         ));
     }
 
@@ -277,13 +279,15 @@ fn _pull(
         command.arg(format!(
             "{user}@{remote_machine_name}:{project_dir_on_remote_machine}",
             remote_machine_name = config.remote.host,
-            project_dir_on_remote_machine = project_dir_on_remote_machine(config, local_dir_absolute_path)
+            project_dir_on_remote_machine =
+                project_dir_on_remote_machine(config, local_dir_absolute_path)
         ));
     } else {
         command.arg(format!(
             "{remote_machine_name}:{project_dir_on_remote_machine}",
             remote_machine_name = config.remote.host,
-            project_dir_on_remote_machine = project_dir_on_remote_machine(config, local_dir_absolute_path)
+            project_dir_on_remote_machine =
+                project_dir_on_remote_machine(config, local_dir_absolute_path)
         ));
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -81,7 +81,7 @@ pub fn push(
     command
         .arg(format!(
             "--rsync-path=mkdir -p {} && rsync",
-            project_dir_on_remote_machine(&config, local_dir_absolute_path)
+            project_dir_on_remote_machine(config, local_dir_absolute_path)
         ))
         .arg(format!("--compress-level={}", config.push.compression));
 
@@ -99,13 +99,13 @@ pub fn push(
         command.arg(format!(
             "{user}@{remote_machine_name}:{project_dir_on_remote_machine}",
             remote_machine_name = config.remote.host,
-            project_dir_on_remote_machine = project_dir_on_remote_machine(&config, local_dir_absolute_path)
+            project_dir_on_remote_machine = project_dir_on_remote_machine(config, local_dir_absolute_path)
         ));
     } else {
         command.arg(format!(
             "{remote_machine_name}:{project_dir_on_remote_machine}",
             remote_machine_name = config.remote.host,
-            project_dir_on_remote_machine = project_dir_on_remote_machine(&config, local_dir_absolute_path)
+            project_dir_on_remote_machine = project_dir_on_remote_machine(config, local_dir_absolute_path)
         ));
     }
 
@@ -277,13 +277,13 @@ fn _pull(
         command.arg(format!(
             "{user}@{remote_machine_name}:{project_dir_on_remote_machine}",
             remote_machine_name = config.remote.host,
-            project_dir_on_remote_machine = project_dir_on_remote_machine(&config, local_dir_absolute_path)
+            project_dir_on_remote_machine = project_dir_on_remote_machine(config, local_dir_absolute_path)
         ));
     } else {
         command.arg(format!(
             "{remote_machine_name}:{project_dir_on_remote_machine}",
             remote_machine_name = config.remote.host,
-            project_dir_on_remote_machine = project_dir_on_remote_machine(&config, local_dir_absolute_path)
+            project_dir_on_remote_machine = project_dir_on_remote_machine(config, local_dir_absolute_path)
         ));
     }
 


### PR DESCRIPTION
This PR adds a static path config option.

This allows for using mainframer in scenarios where the server path needs to be consistent, such as when interfacing with a cluster setup.

Example `config.yml`
```
remote:
  host: localhost
  port: 2222
  path: /app/mainframer/
pull:
  mode: parallel
```