### PR TITLE
Added user definitions for push and pull

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -131,7 +131,10 @@ pull:
                     host: String::from("computer1"),
                     ..Default::default()
                 },
-                push: Push { compression: 5, ..Default::default() },
+                push: Push {
+                    compression: 5,
+                    ..Default::default()
+                },
                 pull: Pull {
                     compression: 2,
                     mode: PullMode::Serial,
@@ -160,7 +163,10 @@ pull:
                     host: String::from("computer1"),
                     ..Default::default()
                 },
-                push: Push { compression: 5, ..Default::default() },
+                push: Push {
+                    compression: 5,
+                    ..Default::default()
+                },
                 pull: Pull {
                     compression: 2,
                     mode: PullMode::Serial,
@@ -189,7 +195,10 @@ pull:
                     host: String::from("computer1"),
                     ..Default::default()
                 },
-                push: Push { compression: 5, ..Default::default() },
+                push: Push {
+                    compression: 5,
+                    ..Default::default()
+                },
                 pull: Pull {
                     compression: 2,
                     mode: PullMode::Serial,

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,7 @@ impl Config {
 }
 
 #[derive(Debug, Default, Eq, PartialEq, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Remote {
     pub host: String,
     pub user: Option<String>,
@@ -64,6 +65,7 @@ pub struct Remote {
 pub struct Push {
     #[serde(default = "Push::default_compression")]
     pub compression: i8,
+    pub user: Option<String>,
 }
 
 impl Push {
@@ -74,7 +76,10 @@ impl Push {
 
 impl Default for Push {
     fn default() -> Self {
-        Self { compression: 3 }
+        Self {
+            compression: 3,
+            user: None,
+        }
     }
 }
 
@@ -84,6 +89,7 @@ pub struct Pull {
     pub compression: i8,
     #[serde(default)]
     pub mode: PullMode,
+    pub user: Option<String>,
 }
 
 impl Pull {
@@ -97,6 +103,7 @@ impl Default for Pull {
         Self {
             compression: 1,
             mode: PullMode::default(),
+            user: None,
         }
     }
 }
@@ -124,10 +131,11 @@ pull:
                     host: String::from("computer1"),
                     ..Default::default()
                 },
-                push: Push { compression: 5 },
+                push: Push { compression: 5, ..Default::default() },
                 pull: Pull {
                     compression: 2,
                     mode: PullMode::Serial,
+                    ..Default::default()
                 },
             })
         );
@@ -152,10 +160,11 @@ pull:
                     host: String::from("computer1"),
                     ..Default::default()
                 },
-                push: Push { compression: 5 },
+                push: Push { compression: 5, ..Default::default() },
                 pull: Pull {
                     compression: 2,
                     mode: PullMode::Serial,
+                    ..Default::default()
                 },
             })
         );
@@ -180,10 +189,11 @@ pull:
                     host: String::from("computer1"),
                     ..Default::default()
                 },
-                push: Push { compression: 5 },
+                push: Push { compression: 5, ..Default::default() },
                 pull: Pull {
                     compression: 2,
                     mode: PullMode::Serial,
+                    ..Default::default()
                 },
             })
         );
@@ -237,6 +247,7 @@ remote:
                         push: if destination == "push" {
                             Push {
                                 compression: compression_level,
+                                ..Default::default()
                             }
                         } else {
                             Push::default()

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -98,7 +98,7 @@ pub fn push(
 
     command.arg("./");
 
-    if let Some(user) = &config.remote.user {
+    if let Some(user) = &config.push.user {
         command.arg(format!(
             "{user}@{remote_machine_name}:{project_dir_on_remote_machine}",
             remote_machine_name = config.remote.host,
@@ -284,7 +284,7 @@ fn _pull(
         apply_exclude_from(&mut command, ignore.pull());
     }
 
-    if let Some(user) = &config.remote.user {
+    if let Some(user) = &config.pull.user {
         command.arg(format!(
             "{user}@{remote_machine_name}:{project_dir_on_remote_machine}",
             remote_machine_name = config.remote.host,


### PR DESCRIPTION
This PR allows you to define users for push and pull. This is useful for certain scenarios where the server may be able to respond to using different users, such as our case where we sync on cheaper nodes and exec on more expensive ones